### PR TITLE
Changed the xmlChildren.XMLNode function not to produce warnings

### DIFF
--- a/R/XMLClasses.R
+++ b/R/XMLClasses.R
@@ -192,7 +192,10 @@ xmlChildren.XMLNode <-
 #
 function(x, addNames = TRUE, ...)
 {
-  structure(x$children, class = "XMLNodeList")
+   if(is.null(x$children)){
+      return(structure(list(), class = "XMLNodeList"))
+    }
+    structure(x$children, class = "XMLNodeList")
 }
 
 


### PR DESCRIPTION
Dear developer, your call of structure causes warnings in R-3.4.0. To avoid this I restructured the code