### PR TITLE
Fix for getRelativeURL & URI character coercer

### DIFF
--- a/R/getRelativeURL.R
+++ b/R/getRelativeURL.R
@@ -54,9 +54,10 @@ function(u, baseURL, sep = "/", addBase = TRUE, simplify = TRUE, escapeQuery = F
           u = substring(u, 3)
       
       #handle ../ occurences
-      parent_levels <- length(gregexpr("\\.\\./",b$path)[[1]])
+      parent_levels <- gregexpr("\\.\\./",u)[[1]]
+      parent_levels <- parent_levels[parent_levels!=-1]
       if(length(parent_levels)>0)
-        for(i in 1:parent_levels) bdir <- dirname(bdir)
+        for(i in 1:length(parent_levels)) bdir <- dirname(bdir)
         if(bdir=="/") bdir <- ""
         u <- gsub("\\.\\./","",u)  
           

--- a/R/getRelativeURL.R
+++ b/R/getRelativeURL.R
@@ -48,11 +48,19 @@ function(u, baseURL, sep = "/", addBase = TRUE, simplify = TRUE, escapeQuery = F
 
 
       endsWithSlash = grepl("/$", b$path)
-
+      bdir <- if(endsWithSlash) b$path else dirname(b$path)
+      sep <- if(endsWithSlash) "" else sep
       if(endsWithSlash && grepl("^\\./", u))
           u = substring(u, 3)
+      
+      #handle ../ occurences
+      parent_levels <- length(gregexpr("\\.\\./",b$path)[[1]])
+      if(length(parent_levels)>0)
+        for(i in 1:parent_levels) bdir <- dirname(bdir)
+        if(bdir=="/") bdir <- ""
+        u <- gsub("\\.\\./","",u)  
           
-      b$path = sprintf("%s%s%s", if(endsWithSlash) b$path else dirname(b$path), if(endsWithSlash) "" else sep, u)
+      b$path = sprintf("%s%s%s", bdir, sep, u)
         # handle .. in the path and try to collapse these.
       if(simplify && grepl("..", b$path, fixed = TRUE))
         b$path = simplifyPath(b$path)

--- a/R/htmlParse.R
+++ b/R/htmlParse.R
@@ -159,12 +159,14 @@ setAs("URI", "character",
                       if(from[["query"]] != "") sprintf("?%s", from[["query"]]) else "",
                       if(from[["fragment"]] != "") sprintf("#%s", from[["fragment"]]) else "" )
           else
+           hasPort <- FALSE
+           if(!is.na(from[["port"]])) if(from[["port"]] > 0) hasPort <- TRUE
            sprintf("%s://%s%s%s%s%s%s%s",
                                     from[["scheme"]],
                                     from[["user"]],
                                     if(from[["user"]] != "") "@" else "",
                                     from[["server"]],
-                                    if(!is.na(from[["port"]])) sprintf(":%d", as.integer(from[["port"]])) else "",
+                                    if(hasPort) sprintf(":%d", as.integer(from[["port"]])) else "",
                                     from["path"],
                                     if(from[["query"]] != "") sprintf("?%s", from[["query"]]) else "",
                                     if(from[["fragment"]] != "") sprintf("#%s", from[["fragment"]]) else ""                   


### PR DESCRIPTION
Dear @duncantl, here's a proposal of fix for ``getRelativeURL`` & the setAs character method for URI objects. I've raised issues while doing attempts to parse local XSD schemas (schemas from https://github.com/eblondel/geometa/tree/master/inst/extdata/schemas) with the XMLSchema package. The issues were:
* with ``getRelativeURL``: handling with relative paths with ``../`` occurences was not working, leading to bad handling of XSD imports/includes.
* with setAs("URI", "character" coercer where with local file paths I was getting port = -1 leading to a bad handling of imports/includes paths.
Thanks in advance if you can review this, and hopefully merge it if code is fine. 